### PR TITLE
experiment with skip function

### DIFF
--- a/sonos_moments/speakers.py
+++ b/sonos_moments/speakers.py
@@ -15,5 +15,17 @@ def speakers_ui() -> None:
                     ui.button(icon='play_arrow', on_click=zone.play).props('flat dense')
                     ui.button(icon='pause', on_click=zone.pause).props('flat dense')
                     ui.button(icon='stop', on_click=zone.stop).props('flat dense')
+                    ui.button('+30s', on_click=lambda zone=zone: skip(zone, 30)).props('flat dense')
             else:
                 ui.element()
+
+
+def skip(zone: soco.SoCo, d_seconds: int) -> None:
+    position = zone.get_current_track_info()['position']  # hh:mm:ss
+    hours, minutes, seconds = map(int, position.split(':'))
+    seconds += d_seconds
+    minutes += seconds // 60
+    seconds %= 60
+    hours += minutes // 60
+    minutes %= 60
+    zone.seek(f'{hours:02d}:{minutes:02d}:{seconds:02d}')


### PR DESCRIPTION
This PR tries to implement a "skip ahead" button. A proof of concept works already. The main question is how to extend the UI without breaking the layout on small mobile screens. Maybe we convert speakers into `ui.expansion` elements if they are coordinators, i.e. if they display a button group with playback controls.

<img width="329" alt="Screenshot 2024-06-30 at 13 02 22" src="https://github.com/falkoschindler/sonos_moments/assets/5767091/be5d47a7-1cd2-435a-89ca-34fc6d906044">
